### PR TITLE
Entity/config/parse data set

### DIFF
--- a/lib/dataset/dataset.ts
+++ b/lib/dataset/dataset.ts
@@ -2,5 +2,6 @@ export interface DataSet<T>{
 	count:number,
 	items:Array<T>,
 	next?:string,
-	previous?:string
+	previous?:string,
+	meta?:object
 }

--- a/lib/entity/data-entity.base.ts
+++ b/lib/entity/data-entity.base.ts
@@ -4,11 +4,11 @@ import {EntityConfigBase} from "./entity-config.base";
 import {ModelBase} from "../models/model.base";
 import {EntityId} from "../models/entity-id.type";
 
-export interface DataEntityConstructor<TEntity extends ModelBase, TRawData = any, TId extends EntityId = string> extends DataEntityType<TEntity, TRawData, TId>{
+export interface DataEntityConstructor<TEntity extends ModelBase, TRawData = any, TId extends EntityId = string, TDataSet = any> extends DataEntityType<TEntity, TRawData, TId, TDataSet>{
 	new(data?:any, rawData?:TRawData): TEntity
 }
 
-export interface DataEntityType<TEntity extends ModelBase = any, TRawData = any, TId extends EntityId = string>{
+export interface DataEntityType<TEntity extends ModelBase = any, TRawData = any, TId extends EntityId = string, TDataSet = any>{
 	new(data?:EntityModelConfigBase, rawData?:TRawData):TEntity,
 	singularName?:string,
 	pluralName?:string,

--- a/lib/entity/entity.decorator.ts
+++ b/lib/entity/entity.decorator.ts
@@ -2,8 +2,8 @@ import {EntityConfig, ModelEntity} from "./entity.config";
 import {DataEntityType} from "./data-entity.base";
 import {entitiesService} from "../services/entities.service";
 
-export function Entity(config:EntityConfig<any, any, any>){
-	return (target:DataEntityType<any, any, any>) => {
+export function Entity(config:EntityConfig<any, any, any, any>){
+	return (target:DataEntityType<any, any, any, any>) => {
 		let entity:ModelEntity = new ModelEntity(config, target.prototype.constructor);
 		target.entityConfig = entity;
 		target.singularName = config.singularName;

--- a/lib/mock/todo-list.entity.ts
+++ b/lib/mock/todo-list.entity.ts
@@ -1,0 +1,28 @@
+import {EntityModelBase} from "../models/entity-model.base";
+import {Entity} from "../entity/entity.decorator";
+import {EntityField} from "../entity/entity-field.decorator";
+
+@Entity({
+	singularName: "Todo list",
+	pluralName: "Todo lists",
+	endpoint: "list",
+	parseDataSet: (rawDataSet:TodoListRawDataSet) => ({
+		items: rawDataSet.lists,
+		next: rawDataSet.$nextPage,
+		count: rawDataSet.total,
+		meta: {
+			lastUpdate: new Date(rawDataSet.lastUpdate)
+		}
+	})
+})
+export class TodoList extends EntityModelBase<number>{
+	@EntityField()
+	name:string;
+}
+
+interface TodoListRawDataSet {
+	lists: Array<any>,
+	$nextPage: string,
+	total: number,
+	lastUpdate: number
+}

--- a/lib/repository/data-to-model.spec.ts
+++ b/lib/repository/data-to-model.spec.ts
@@ -1,0 +1,61 @@
+import { suite, test, slow, timeout } from "mocha-typescript";
+import "reflect-metadata"
+import * as chai from 'chai';
+import '../services/paris.init.spec';
+import {DataSet} from "../dataset/dataset";
+import {parseDataSet} from "./data-to-model";
+
+const expect = chai.expect;
+
+const rawDataSet:RawDataSet = {
+	results: [
+		{
+			id: 1,
+			name: "First"
+		},
+		{
+			id: 2,
+			name: "Seconds"
+		}
+	],
+	$next: '/api/todolist?page=2',
+	total: 123
+};
+
+describe('Raw data -> model', () => {
+	describe('Create a DataSet', () => {
+		let dataSet:DataSet<SimpleEntity>;
+
+		before(() => {
+			console.log("REFLECT", Reflect);
+			dataSet = parseDataSet<SimpleEntity, RawDataSet>(rawDataSet, 'results', parseRawDataSet);
+		});
+
+		it('has items', () => {
+			expect(dataSet.items.length).to.equal(rawDataSet.results.length);
+		});
+
+		it('has a next property', () => {
+			expect(dataSet.next).to.equal(rawDataSet.$next);
+		})
+	});
+});
+
+function parseRawDataSet(rawDataSet:RawDataSet):DataSet<SimpleEntity>{
+	return {
+		items: rawDataSet.results,
+		next: rawDataSet.$next,
+		count: rawDataSet.total
+	}
+}
+
+interface SimpleEntity{
+	id:number,
+	name:string
+}
+
+interface RawDataSet {
+	results: Array<SimpleEntity>,
+	$next: string,
+	total: number
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"build": "gulp build",
 		"dev": "rollup -c -w",
 		"prepublishOnly": "npm run build",
-		"test": "mocha -r ts-node/register lib/**/*.spec.ts",
+		"test": "mocha --opts ./test/mocha.opts",
 		"docs": "typedoc --options typedocconfig.ts"
 	},
 	"author": "Yossi Kolesnicov",
@@ -50,7 +50,7 @@
 		"gulp-typescript": "^3.1.3",
 		"husky": "^1.0.0-rc.13",
 		"intl": "^1.2.5",
-		"lodash.get": "^4.4.2",
+		"lodash-es": "4.17.10",
 		"merge2": "^1.0.2",
 		"mocha": "^5.2.0",
 		"reflect-metadata": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Library for the implementation of Domain Driven Design in Angular/TypeScript apps",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Library for the implementation of Domain Driven Design in Angular/TypeScript apps",
 	"repository": {
 		"type": "git",
-		"url": "https://microsoft.visualstudio.com/DefaultCollection/WDATP/_git/Paris"
+		"url": "https://github.com/Microsoft/paris"
 	},
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.2.0",
+	"version": "1.1.1",
 	"description": "Library for the implementation of Domain Driven Design in Angular/TypeScript apps",
 	"repository": {
 		"type": "git",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--ui mocha-typescript
+lib/**/*.spec.ts


### PR DESCRIPTION
Added parseDataSet to entity backend config, so it's possible to parse the object returned from an API for a query.

Also, some unit testing definitions.