### PR TITLE
Add ability to model any number of subclasses for a given entity

### DIFF
--- a/lib/entity/entity-config.base.ts
+++ b/lib/entity/entity-config.base.ts
@@ -1,11 +1,11 @@
-import {EntityFields} from "./entity-fields";
-import {Immutability} from "../services/immutability";
-import {DataEntityConstructor} from "./data-entity.base";
-import {ParisConfig} from "../config/paris-config";
-import {ModelBase} from "../models/model.base";
-import {HttpOptions} from "../services/http.service";
-import {EntityId} from "../models/entity-id.type";
-import {Field} from "./entity-field";
+import { ParisConfig } from "../config/paris-config";
+import { EntityId } from "../models/entity-id.type";
+import { ModelBase } from "../models/model.base";
+import { HttpOptions } from "../services/http.service";
+import { Immutability } from "../services/immutability";
+import { DataEntityConstructor } from "./data-entity.base";
+import { Field } from "./entity-field";
+import { EntityFields } from "./entity-fields";
 
 const DEFAULT_VALUE_ID = "__default";
 
@@ -101,32 +101,33 @@ export interface IEntityConfigBase<TEntity extends ModelBase = any, TRawData = a
 	/**
 	 * Hard-coded items for this Entity. When values are specified, no endpoint is required, and items are always returned from these values, instead of backend.
 	 *
-	 * @example <caption>Hard-coding values for an Entity</caption>
-	 * ```typescript
-	 * @Entity({
-	 * 		singularName: "Status",
-	 * 		pluralName: "Statuses",
-	 * 		values: [
-	 * 			{ id: 1, name: 'Open' },
-	 * 			{ id: 2, name: 'In progress' },
-	 * 			{ id: 3, name: 'Done' }
-	 * 		]
-	 * })
-	 * export class Status extends EntityModelBase<number>{
-	 * 		@EntityField()
-	 * 		name: string;
-	 * }
-	 * ```
+	 * Hard-coding values for an Entity:
+	 * @example
+```typescript
+@Entity({
+	singularName: "Status",
+	pluralName: "Statuses",
+	values: [
+		{ id: 1, name: 'Open' },
+		{ id: 2, name: 'In progress' },
+		{ id: 3, name: 'Done' }
+	]
+})
+export class Status extends EntityModelBase<number>{
+	@EntityField()
+	name: string;
+}
+```
 	 *
 	 * Then when requesting an item for Status, either directly (with getValue or getItemById) or when sub-modeling, the hard-coded values are used:
 	 *
-	 * ```typescript
-	 * // Async way:
-	 * paris.getItemById(Status, 1).subscribe(status => console.log('Status with ID 1: ', status);
-	 *
-	 * // Sync:
-	 * console.log('Status with ID 1: ', paris.getValue(Status, 1));
-	 * ```
+```typescript
+// Async:
+paris.getItemById(Status, 1).subscribe(status => console.log('Status with ID 1: ', status);
+
+// Sync:
+console.log('Status with ID 1: ', paris.getValue(Status, 1));
+```
 	 */
 	values?:Array<TEntity>,
 
@@ -141,10 +142,30 @@ export interface IEntityConfigBase<TEntity extends ModelBase = any, TRawData = a
 	entityConstructor?:DataEntityConstructor<TEntity, TRawData, TId>,
 	serializeItem?:(item:Partial<TEntity>, serializedItem?:any, entity?:IEntityConfigBase<TEntity, TRawData, TId>, config?:ParisConfig, serializationData?:any) => TRawData,
 	supportedEntityGetMethods?:Array<EntityGetMethod>,
-	parseSaveItemsQuery?: (items:Array<TEntity>, options?:HttpOptions, entity?:IEntityConfigBase<TEntity, TRawData, TId>, config?:ParisConfig) => HttpOptions
+	parseSaveItemsQuery?: (items:Array<TEntity>, options?:HttpOptions, entity?:IEntityConfigBase<TEntity, TRawData, TId>, config?:ParisConfig) => HttpOptions,
+
+	/**
+	 * _Optional_ function to supply the model type to construct, given the raw data.
+	 * Useful for APIs that can return multiple entity types, with a common discriminator to differentiate them.
+	 *
+	 * @example
+	 * ```typescript
+@Entity(
+	modelWith: rawData => rawData.kind === 'one' : One ? Two
+)
+class Base { }
+
+@Entity()
+class One extends Base {}
+
+@Entity()
+class Two extends Base {}
+```
+	 */
+	modelWith?: (data: TRawData) => DataEntityConstructor<any>;
 }
 
-export interface ModelConfig<TEntity extends ModelBase, TRawData = any, TId extends EntityId = string> extends IEntityConfigBase<TEntity, TRawData, TId>{
+export interface ModelConfig<TEntity extends ModelBase, TRawData = any, TId extends EntityId = string> extends IEntityConfigBase<TEntity, TRawData, TId> {
 	fields?:EntityFields,
 	fieldsArray?:Array<Field>,
 }

--- a/lib/entity/entity-config.base.ts
+++ b/lib/entity/entity-config.base.ts
@@ -149,7 +149,15 @@ console.log('Status with ID 1: ', paris.getValue(Status, 1));
 	 * Useful for APIs that can return multiple entity types, with a common discriminator to differentiate them.
 	 *
 	 * @example
-	 * ```typescript
+```json
+GET /things
+[
+	{ "kind": "one", "id": 1 },
+	{ "kind": "two", "id": 2 },
+]
+```
+
+```typescript
 @Entity(
 	modelWith: rawData => rawData.kind === 'one' : One ? Two
 )
@@ -160,6 +168,18 @@ class One extends Base {}
 
 @Entity()
 class Two extends Base {}
+
+paris.getItemById<One | Two>(Base, 1)
+	 .subscribe(item =>
+		console.log(item instanceof One) // true
+	 )
+
+paris.getRepository(Base).query().subscribe(dataSet => {
+	const [ one, two ] = dataSet.items;
+
+	console.log(one instanceof One) // true
+	console.log(two instanceof Two) // true
+});
 ```
 	 */
 	modelWith?: (data: TRawData) => DataEntityConstructor<any>;

--- a/lib/mock/thing.entity.ts
+++ b/lib/mock/thing.entity.ts
@@ -1,0 +1,47 @@
+import { EntityField } from '../entity/entity-field.decorator';
+import { Entity } from '../entity/entity.decorator';
+import { EntityModelBase } from '../models/entity-model.base';
+
+@Entity({
+	singularName: 'Thing',
+	pluralName: 'Things',
+	endpoint: 'things',
+	timeout: 20000,
+	modelWith: rawData => {
+		switch (rawData.type) {
+			case 'animal':
+				return Animal;
+			case 'person':
+				return Person;
+			default:
+				throw new Error(`Invalid type for 'Thing' (got ${rawData.type})`);
+		}
+	},
+})
+export class Thing extends EntityModelBase<number> {
+	@EntityField()
+	type: 'animal' | 'person';
+
+	@EntityField()
+	name: string;
+}
+
+@Entity({
+	singularName: 'Person',
+	pluralName: 'Persons',
+	endpoint: 'things',
+})
+export class Person extends Thing {
+	@EntityField()
+	address: string;
+}
+
+@Entity({
+	singularName: 'Animal',
+	pluralName: 'Animals',
+	endpoint: 'things',
+})
+export class Animal extends Thing {
+	@EntityField()
+	kind: 'dog' | 'cat';
+}

--- a/lib/repository/readonly-repository.spec.ts
+++ b/lib/repository/readonly-repository.spec.ts
@@ -1,0 +1,55 @@
+import { of } from 'rxjs';
+import { Animal, Person, Thing } from '../mock/thing.entity';
+import { DataStoreService } from '../services/data-store.service';
+import { Paris } from '../services/paris';
+
+describe('ReadonlyRepository', () => {
+	describe('getModalData', () => {
+		let paris: Paris;
+
+		beforeEach(() => {
+			paris = new Paris();
+
+			const createData = (endpoint: string) => {
+				// Single item
+				if (/things\/\d+/.test(endpoint)) {
+					return of({ type: 'animal', name: 'woof', kind: 'dog' });
+				}
+
+				return of([
+					{ type: 'animal', name: 'woof', kind: 'dog' },
+					{ type: 'person', name: 'Joe', address: '1 Generic st.' },
+				]);
+			};
+
+			DataStoreService.prototype.get = jest.fn((endpoint: string) => createData(endpoint));
+			DataStoreService.prototype.request = jest.fn((method: string, endpoint: string) =>
+				createData(endpoint)
+			);
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should support derived entity (single)', done => {
+			paris.getItemById(Thing, 1).subscribe(item => {
+				expect(item).toBeInstanceOf(Animal);
+				done();
+			});
+		});
+
+		it('should support derived entity (multiple)', done => {
+			const repository = paris.getRepository(Thing);
+			repository.query().subscribe(({ items }) => {
+				expect(items).toHaveLength(2);
+
+				const [animal, person] = items;
+				expect(animal).toBeInstanceOf(Animal);
+				expect(person).toBeInstanceOf(Person);
+
+				done();
+			});
+		});
+	});
+});

--- a/lib/repository/readonly-repository.ts
+++ b/lib/repository/readonly-repository.ts
@@ -1,31 +1,31 @@
-import {EntityModelBase} from "../models/entity-model.base";
-import {queryToHttpOptions} from "../dataset/query-to-http";
-import {ErrorsService} from "../services/errors.service";
-import {DataSet} from "../dataset/dataset";
-import {DataQuery} from "../dataset/data-query";
-import {DataOptions, defaultDataOptions} from "../dataset/data.options";
-import {combineLatest, merge, Observable, of, Subject} from "rxjs";
-import {HttpOptions} from "../services/http.service";
-import {DataStoreService} from "../services/data-store.service";
-import {ParisConfig} from "../config/paris-config";
-import {EntityBackendConfig, ModelEntity} from "../entity/entity.config";
-import {DataEntityConstructor, DataEntityType} from "../entity/data-entity.base";
-import {Paris} from "../services/paris";
-import {DataAvailability} from "../dataset/data-availability.enum";
-import {Field} from "../entity/entity-field";
-import {DataCache} from "../services/cache";
-import {Index} from "../models";
-import {EntityConfigBase, EntityGetMethod, ModelConfig} from "../entity/entity-config.base";
-import {ModelBase} from "../models/model.base";
-import {DataTransformersService} from "../services/data-transformers.service";
-import {valueObjectsService} from "../services/value-objects.service";
-import {AjaxError} from "rxjs/ajax";
-import {EntityErrorEvent, EntityErrorTypes} from "../events/entity-error.event";
-import {catchError, map, mergeMap, tap} from "rxjs/operators";
-import {IReadonlyRepository} from "./repository.interface";
-import {FIELD_DATA_SELF} from "../entity/entity-field.config";
-import {EntityId} from "../models/entity-id.type";
-import {clone, findIndex, get} from "lodash-es";
+import { clone, findIndex, get } from "lodash-es";
+import { combineLatest, merge, Observable, of, Subject } from "rxjs";
+import { AjaxError } from "rxjs/ajax";
+import { catchError, map, mergeMap, tap } from "rxjs/operators";
+import { ParisConfig } from "../config/paris-config";
+import { DataAvailability } from "../dataset/data-availability.enum";
+import { DataQuery } from "../dataset/data-query";
+import { DataOptions, defaultDataOptions } from "../dataset/data.options";
+import { DataSet } from "../dataset/dataset";
+import { queryToHttpOptions } from "../dataset/query-to-http";
+import { DataEntityConstructor, DataEntityType } from "../entity/data-entity.base";
+import { EntityConfigBase, EntityGetMethod, ModelConfig } from "../entity/entity-config.base";
+import { Field } from "../entity/entity-field";
+import { FIELD_DATA_SELF } from "../entity/entity-field.config";
+import { EntityBackendConfig, ModelEntity } from "../entity/entity.config";
+import { EntityErrorEvent, EntityErrorTypes } from "../events/entity-error.event";
+import { Index } from "../models";
+import { EntityId } from "../models/entity-id.type";
+import { EntityModelBase } from "../models/entity-model.base";
+import { ModelBase } from "../models/model.base";
+import { DataCache } from "../services/cache";
+import { DataStoreService } from "../services/data-store.service";
+import { DataTransformersService } from "../services/data-transformers.service";
+import { ErrorsService } from "../services/errors.service";
+import { HttpOptions } from "../services/http.service";
+import { Paris } from "../services/paris";
+import { valueObjectsService } from "../services/value-objects.service";
+import { IReadonlyRepository } from "./repository.interface";
 
 /**
  * A Repository is a service through which all of an Entity's data is fetched, cached and saved back to the backend.
@@ -311,12 +311,23 @@ export class ReadonlyRepository<TEntity extends ModelBase, TRawData = any> imple
 	 * @param {DataOptions} options
 	 * @returns {Observable<TEntity extends EntityModelBase>}
 	 */
-	static getModelData<TEntity extends ModelBase, TRawData extends any = any>(rawData: TRawData, entity: ModelConfig<TEntity, TRawData>, config: ParisConfig, paris: Paris, options: DataOptions = defaultDataOptions, query?: DataQuery): Observable<TEntity> {
+	static getModelData<TEntity extends ModelBase, TRawData extends any = any, SEntity extends TEntity = TEntity>(rawData: TRawData, entity: ModelConfig<TEntity, TRawData>, config: ParisConfig, paris: Paris, options: DataOptions = defaultDataOptions, query?: DataQuery): Observable<TEntity> {
 		let entityIdProperty: keyof TRawData = entity.idProperty || config.entityIdProperty,
 			modelData: Index = entity instanceof ModelEntity ? {id: rawData[entityIdProperty]} : {},
 			subModels: Array<Observable<{ [index: string]: ModelBase | Array<ModelBase> }>> = [];
 
 		let getModelDataError:Error = new Error(`Failed to create ${entity.singularName}.`);
+
+		if (typeof entity.modelWith === 'function') {
+			const { entityConfig, valueObjectConfig } = entity.modelWith(rawData);
+			return ReadonlyRepository.getModelData<SEntity, TRawData>(
+				rawData,
+				entityConfig || valueObjectConfig,
+				config,
+				paris,
+				options
+			);
+		}
 
 		entity.fields.forEach((entityField: Field) => {
 			if (entityField.require){

--- a/lib/repository/readonly-repository.ts
+++ b/lib/repository/readonly-repository.ts
@@ -304,14 +304,19 @@ export class ReadonlyRepository<TEntity extends ModelBase, TRawData = any> imple
 	 * Populates the item dataset with any sub-model. For example, if an ID is found for a property whose type is an entity,
 	 * the property's value will be an instance of that entity, for the ID, not the ID.
 	 * This method does the actual heavy lifting required for modeling an Entity or ValueObject - parses the fields, models sub-models, etc.
-	 * @param {Index} rawData
-	 * @param {EntityConfigBase} entity
+	 *
+	 * @template TEntity The entity to model
+	 * @template TRawData The raw data
+	 * @template TConcreteEntity An optional entity derived from `TEntity` that will be used if `TEntity` uses `modelWith`
+	 * @param {TRawData} rawData
+	 * @param {ModelConfig<TEntity, TRawData>} entity
 	 * @param {ParisConfig} config
 	 * @param {Paris} paris
-	 * @param {DataOptions} options
-	 * @returns {Observable<TEntity extends EntityModelBase>}
+	 * @param {DataOptions} [options=defaultDataOptions]
+	 * @param {DataQuery} [query]
+	 * @returns {Observable<TEntity> | Observable<TConcreteEntity>}
 	 */
-	static getModelData<TEntity extends ModelBase, TRawData extends any = any, SEntity extends TEntity = TEntity>(rawData: TRawData, entity: ModelConfig<TEntity, TRawData>, config: ParisConfig, paris: Paris, options: DataOptions = defaultDataOptions, query?: DataQuery): Observable<TEntity> {
+	static getModelData<TEntity extends ModelBase, TRawData extends any = any, TConcreteEntity extends TEntity = TEntity>(rawData: TRawData, entity: ModelConfig<TEntity, TRawData>, config: ParisConfig, paris: Paris, options: DataOptions = defaultDataOptions, query?: DataQuery) : TEntity extends TConcreteEntity ? Observable<TEntity> : Observable<TConcreteEntity> {
 		let entityIdProperty: keyof TRawData = entity.idProperty || config.entityIdProperty,
 			modelData: Index = entity instanceof ModelEntity ? {id: rawData[entityIdProperty]} : {},
 			subModels: Array<Observable<{ [index: string]: ModelBase | Array<ModelBase> }>> = [];
@@ -320,7 +325,7 @@ export class ReadonlyRepository<TEntity extends ModelBase, TRawData = any> imple
 
 		if (typeof entity.modelWith === 'function') {
 			const { entityConfig, valueObjectConfig } = entity.modelWith(rawData);
-			return ReadonlyRepository.getModelData<SEntity, TRawData>(
+			return ReadonlyRepository.getModelData<TConcreteEntity, TRawData>(
 				rawData,
 				entityConfig || valueObjectConfig,
 				config,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,20 @@
 		"test:watch": "jest --watch",
 		"docs": "typedoc --options typedocconfig.ts"
 	},
-	"author": "Yossi Kolesnicov",
+	"author": {
+		"name": "Yossi Kolesnicov",
+		"email": "Yossi.Kolesnicov@microsoft.com"
+	},
+	"contributors": [
+		{
+			"name": "Shai Rose",
+			"email": "Shai.Rose@microsoft.com"
+		},
+		{
+			"name": "Ben Grynhaus",
+			"email": "bengr@microsoft.com"
+		}
+	],
 	"license": "MIT",
 	"devDependencies": {
 		"@compodoc/compodoc": "^1.0.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
 			"email": "Shai.Rose@microsoft.com"
 		},
 		{
+			"name": "Omer Mizrahi",
+			"email": "Omer.Mizrahi@microsoft.com"
+		},
+		{
 			"name": "Ben Grynhaus",
 			"email": "bengr@microsoft.com"
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"description": "Library for the implementation of Domain Driven Design in Angular/TypeScript apps",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Relies on #4 (tests for this PR are using `jest`).

Also fixes some JDocs I faced that seemed to be using markdown, but weren't being parsed correctly, or not indented correctly.

Note that this PR also changes the package to `v1.2.0`.