### PR TITLE
Fix hashing when passing an object with circular dependencies to an ApiCall as a paramter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cSpell.words": [
         "repo",
         "todolist"
-    ]
+    ],
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ Paris is a data management library for webapps, using TypeScript and RxJS to imp
 
 *Package size: ~15.8kb (gzipped)*
 
-1. Paris is a TypeScript library and also requires RxJs and lodash, so you'll need both those packages, if you don't already use them:
+1. Paris is a TypeScript library and also requires RxJS and lodash-es, so you'll need both those packages, if you don't already use them:
 
 	```
-	npm install --save lodash-es rxjs typescript
+	npm install --save lodash-es rxjs typescript object-hash
+	```
+
+    1.1. If you plan to use caching, you'll also need to install `object-hash`:
+	```
+	npm install --save object-hash
 	```
 
 2. Install the Paris NPM package:

--- a/lib/repository/readonly-repository.ts
+++ b/lib/repository/readonly-repository.ts
@@ -452,7 +452,8 @@ export class ReadonlyRepository<TEntity extends ModelBase, TRawData = any> imple
 			model$ = of(model);
 		}
 
-		return entity.readonly ? model$.pipe(map(model => Object.freeze(model))) : model$;
+		// typecasting is used here until bug in TS is fixed (https://github.com/Microsoft/TypeScript/issues/26495)
+		return (entity.readonly ? model$.pipe(map(model => Object.freeze(model))) : model$) as TEntity extends TConcreteEntity ? Observable<TEntity> : Observable<TConcreteEntity>;
 	}
 
 	private static getSubModel(entityField:Field, value:any, paris:Paris, config:ParisConfig, options: DataOptions = defaultDataOptions):Observable<ModelPropertyValue>{

--- a/lib/services/paris.ts
+++ b/lib/services/paris.ts
@@ -1,34 +1,35 @@
-import {defaultConfig, ParisConfig} from "../config/paris-config";
-import {DataEntityConstructor, DataEntityType} from "../entity/data-entity.base";
-import {Repository} from "../repository/repository";
-import {EntityBackendConfig, EntityConfig} from "../entity/entity.config";
-import {entitiesService} from "./entities.service";
-import {IRepository} from "../repository/repository.interface";
-import {DataStoreService} from "./data-store.service";
-import {EntityConfigBase} from "../entity/entity-config.base";
-import {Observable, of, Subject, throwError} from "rxjs";
-import {SaveEntityEvent} from "../events/save-entity.event";
-import {RemoveEntitiesEvent} from "../events/remove-entities.event";
-import {IRelationshipRepository, RelationshipRepository} from "../repository/relationship-repository";
-import {ModelBase} from "../models/model.base";
-import {valueObjectsService} from "./value-objects.service";
-import {EntityRelationshipRepositoryType} from "../entity/entity-relationship-repository-type";
-import {DataSet} from "../dataset/dataset";
-import {DataQuery} from "../dataset/data-query";
-import {DataOptions, defaultDataOptions} from "../dataset/data.options";
-import {ReadonlyRepository} from "../repository/readonly-repository";
-import {queryToHttpOptions} from "../dataset/query-to-http";
-import {HttpOptions, RequestMethod, UrlParams} from "./http.service";
-import {EntityErrorEvent, EntityErrorTypes} from "../events/entity-error.event";
-import {ApiCallType} from "../models/api-call.model";
-import {ApiCallBackendConfigInterface} from "../models/api-call-backend-config.interface";
-import {modelArray, rawDataToDataSet} from "../repository/data-to-model";
-import {catchError, map, mergeMap, switchMap, tap} from "rxjs/operators";
-import {DataTransformersService} from "./data-transformers.service";
-import {DataCache, DataCacheSettings} from "./cache";
-import {EntityModelBase} from "../models/entity-model.base";
-import {EntityId} from "../models/entity-id.type";
-import {clone} from "lodash-es";
+import { clone } from "lodash-es";
+import * as hashObject from 'object-hash';
+import { Observable, of, Subject, throwError } from "rxjs";
+import { catchError, map, mergeMap, switchMap, tap } from "rxjs/operators";
+import { defaultConfig, ParisConfig } from "../config/paris-config";
+import { DataQuery } from "../dataset/data-query";
+import { DataOptions, defaultDataOptions } from "../dataset/data.options";
+import { DataSet } from "../dataset/dataset";
+import { queryToHttpOptions } from "../dataset/query-to-http";
+import { DataEntityConstructor, DataEntityType } from "../entity/data-entity.base";
+import { EntityConfigBase } from "../entity/entity-config.base";
+import { EntityRelationshipRepositoryType } from "../entity/entity-relationship-repository-type";
+import { EntityBackendConfig, EntityConfig } from "../entity/entity.config";
+import { EntityErrorEvent, EntityErrorTypes } from "../events/entity-error.event";
+import { RemoveEntitiesEvent } from "../events/remove-entities.event";
+import { SaveEntityEvent } from "../events/save-entity.event";
+import { ApiCallBackendConfigInterface } from "../models/api-call-backend-config.interface";
+import { ApiCallType } from "../models/api-call.model";
+import { EntityId } from "../models/entity-id.type";
+import { EntityModelBase } from "../models/entity-model.base";
+import { ModelBase } from "../models/model.base";
+import { modelArray, rawDataToDataSet } from "../repository/data-to-model";
+import { ReadonlyRepository } from "../repository/readonly-repository";
+import { IRelationshipRepository, RelationshipRepository } from "../repository/relationship-repository";
+import { Repository } from "../repository/repository";
+import { IRepository } from "../repository/repository.interface";
+import { DataCache, DataCacheSettings } from "./cache";
+import { DataStoreService } from "./data-store.service";
+import { DataTransformersService } from "./data-transformers.service";
+import { entitiesService } from "./entities.service";
+import { HttpOptions, RequestMethod, UrlParams } from "./http.service";
+import { valueObjectsService } from "./value-objects.service";
 
 export class Paris{
 	private repositories:Map<DataEntityType, IRepository<ModelBase>> = new Map;
@@ -143,7 +144,7 @@ export class Paris{
 	 * @returns {Observable<TResult>} An Observable of the api call's result data type
 	 */
 	apiCall<TResult = any, TInput = any>(apiCallType:ApiCallType<TResult, TInput>, input?:TInput, dataOptions:DataOptions = defaultDataOptions):Observable<TResult>{
-		const cacheKey:string = JSON.stringify(input) || "{}";
+		const cacheKey:string = hashObject(input || {});
 
 		if (dataOptions.allowCache) {
 			const apiCallTypeCache: DataCache<TResult> = this.getApiCallCache<TResult, TInput>(apiCallType);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@types/jest": "^23.3.1",
 		"@types/lodash-es": "4.17.1",
 		"@types/node": "^8.0.25",
+		"@types/object-hash": "^1.2.0",
 		"@types/rimraf": "2.0.2",
 		"@types/run-sequence": "^0.0.29",
 		"@types/systemjs": "^0.20.2",
@@ -65,6 +66,7 @@
 		"jest": "^23.5.0",
 		"lodash-es": "4.17.10",
 		"merge2": "^1.0.2",
+		"object-hash": "^1.3.0",
 		"reflect-metadata": "^0.1.12",
 		"rimraf": "~2.5.4",
 		"rollup": "^0.50.0",
@@ -85,6 +87,9 @@
 		"rxjs": ">=6.0.0",
 		"lodash-es": "4.5.0"
 	},
+	"optionalDependencies": {
+		"object-hash": "^1.3.0"
+	},
 	"jest": {
 		"transform": {
 			"^.+\\.(js|ts)$": "ts-jest"
@@ -104,6 +109,5 @@
 		"transformIgnorePatterns": [
 			"<rootDir>/node_modules/(?!lodash-es)"
 		]
-	},
-	"dependencies": {}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Library for the implementation of Domain Driven Design in Angular/TypeScript apps",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Currently Paris uses `JSON.stringify` as an object hash when making usage of `ApiCall`.
This doesn't allow abstraction of parameter extraction from an entity, for example:
```typescript
@Entity({
  ...
})
export class Todo extends EntityModelBase<string> {
  ...
}

@ApiCall({
  ...
  endpoint: (config, query) => `todos/${todoId}/comment`
  parseQuery: (todo: Todo) => ({ todoId: todo.id })
})
export class TodoCommentApiCall extends ApiCallModel<..., Todo> {}
```

since `Todo` is an `EntityModelBase` it has a `$parent` property which may be a circular reference.

In this case we can change the parameters of `TodoCommentApiCall` to be `{ todoId: Todo['id'] }`, but if you have more than a few things you need from the entity, this is very cumbersome, and is prone to code duplication in the application (each usage needs to extract the parameters from the entity before handing off to Paris).

The solution is to use a more safe approach to hashing, namely [`object-hash`](https://www.npmjs.com/package/object-hash), to create hashes from object in a consistant and safe manner.

No breaking changes expected, apart from adding another `peerDependency` (this can be mitigated with adding `object-hash` as a `bundleDependencies`, but I'd like to avoid it if possible, if only to reduce the chance of duplicated libraries in different versions at runtime).
Note that this is an `optionalDependencies` since if you don't use caching or `ApiCall`s at all - this is unneeded.	