### PR TITLE
Fix hashing when passing an object with circular dependencies to an ApiCall as a parameter

### DIFF
--- a/lib/data_access/cache.ts
+++ b/lib/data_access/cache.ts
@@ -1,5 +1,6 @@
-import {from, Observable, of} from "rxjs";
-import {finalize, share, tap} from "rxjs/operators";
+import * as jsonStringify from 'json-stringify-safe';
+import { from, Observable, of } from "rxjs";
+import { finalize, share, tap } from "rxjs/operators";
 
 export class DataCache<T = any>{
 	time:((item:T) => number) | number;
@@ -137,7 +138,7 @@ export class DataCache<T = any>{
 	}
 
 	private getCacheKey(key:string, params?:{ [index:string]: any }):string{
-		return key + (params !== undefined && params !== null ? "_" + JSON.stringify(params) : "");
+		return key + (params !== undefined && params !== null ? "_" + jsonStringify(params) : "");
 	}
 
 	/**

--- a/lib/data_access/data-store.service.ts
+++ b/lib/data_access/data-store.service.ts
@@ -1,8 +1,9 @@
-import {ParisConfig} from "../config/paris-config";
-import {Http, HttpOptions, RequestMethod, SaveRequestMethod} from "./http.service";
-import {Observable} from "rxjs";
-import {finalize, share, tap} from "rxjs/operators";
-import {AjaxRequest} from "rxjs/ajax";
+import * as jsonStringify from 'json-stringify-safe';
+import { Observable } from "rxjs";
+import { AjaxRequest } from "rxjs/ajax";
+import { finalize, share, tap } from "rxjs/operators";
+import { ParisConfig } from "../config/paris-config";
+import { Http, HttpOptions, RequestMethod, SaveRequestMethod } from "./http.service";
 
 export class DataStoreService{
 	private activeRequests:Map<string, Observable<any>> = new Map();
@@ -55,7 +56,7 @@ export class DataStoreService{
 	}
 
 	private static getActiveRequestId(method:RequestMethod, endpoint:string, data?:RequestData):string{
-		return `${method}__${endpoint}__${data ? JSON.stringify(data) : '|'}`;
+		return `${method}__${endpoint}__${data ? jsonStringify(data) : '|'}`;
 	}
 }
 

--- a/lib/paris.ts
+++ b/lib/paris.ts
@@ -1,34 +1,35 @@
-import {defaultConfig, ParisConfig} from "./config/paris-config";
-import {DataEntityType} from "./api/entity/data-entity.base";
-import {Repository} from "./api/repository/repository";
-import {EntityBackendConfig, EntityConfig} from "./config/entity.config";
-import {entitiesService} from "./config/services/entities.service";
-import {IRepository} from "./api/repository/repository.interface";
-import {DataStoreService} from "./data_access/data-store.service";
-import {EntityConfigBase} from "./config/model-config";
-import {Observable, of, Subject, throwError} from "rxjs";
-import {SaveEntityEvent} from "./api/events/save-entity.event";
-import {RemoveEntitiesEvent} from "./api/events/remove-entities.event";
-import {IRelationshipRepository, RelationshipRepository} from "./api/repository/relationship-repository";
-import {ModelBase} from "./config/model.base";
-import {valueObjectsService} from "./config/services/value-objects.service";
-import {EntityRelationshipRepositoryType} from "./api/entity/entity-relationship-repository-type";
-import {ReadonlyRepository} from "./api/repository/readonly-repository";
-import {HttpOptions, RequestMethod, UrlParams} from "./data_access/http.service";
-import {EntityErrorEvent, EntityErrorTypes} from "./api/events/entity-error.event";
-import {ApiCallType} from "./api/api-calls/api-call.model";
-import {ApiCallBackendConfigInterface} from "./config/api-call-backend-config.interface";
-import {Modeler} from "./modeling/modeler";
-import {catchError, map, mergeMap, switchMap, tap} from "rxjs/operators";
-import {DataTransformersService} from "./modeling/data-transformers.service";
-import {DataCache, DataCacheSettings} from "./data_access/cache";
-import {EntityModelBase} from "./config/entity-model.base";
-import {EntityId} from "./modeling/entity-id.type";
-import {clone} from "lodash-es";
-import {DataQuery} from "./data_access/data-query";
-import {DataOptions, defaultDataOptions} from "./data_access/data.options";
-import {DataSet} from "./data_access/dataset";
-import {queryToHttpOptions} from "./data_access/query-to-http";
+import * as jsonStringify from 'json-stringify-safe';
+import { clone } from "lodash-es";
+import { Observable, of, Subject, throwError } from "rxjs";
+import { catchError, map, mergeMap, switchMap, tap } from "rxjs/operators";
+import { ApiCallType } from "./api/api-calls/api-call.model";
+import { DataEntityType } from "./api/entity/data-entity.base";
+import { EntityRelationshipRepositoryType } from "./api/entity/entity-relationship-repository-type";
+import { EntityErrorEvent, EntityErrorTypes } from "./api/events/entity-error.event";
+import { RemoveEntitiesEvent } from "./api/events/remove-entities.event";
+import { SaveEntityEvent } from "./api/events/save-entity.event";
+import { ReadonlyRepository } from "./api/repository/readonly-repository";
+import { IRelationshipRepository, RelationshipRepository } from "./api/repository/relationship-repository";
+import { Repository } from "./api/repository/repository";
+import { IRepository } from "./api/repository/repository.interface";
+import { ApiCallBackendConfigInterface } from "./config/api-call-backend-config.interface";
+import { EntityModelBase } from "./config/entity-model.base";
+import { EntityBackendConfig, EntityConfig } from "./config/entity.config";
+import { EntityConfigBase } from "./config/model-config";
+import { ModelBase } from "./config/model.base";
+import { defaultConfig, ParisConfig } from "./config/paris-config";
+import { entitiesService } from "./config/services/entities.service";
+import { valueObjectsService } from "./config/services/value-objects.service";
+import { DataCache, DataCacheSettings } from "./data_access/cache";
+import { DataQuery } from "./data_access/data-query";
+import { DataStoreService } from "./data_access/data-store.service";
+import { DataOptions, defaultDataOptions } from "./data_access/data.options";
+import { DataSet } from "./data_access/dataset";
+import { HttpOptions, RequestMethod, UrlParams } from "./data_access/http.service";
+import { queryToHttpOptions } from "./data_access/query-to-http";
+import { DataTransformersService } from "./modeling/data-transformers.service";
+import { EntityId } from "./modeling/entity-id.type";
+import { Modeler } from "./modeling/modeler";
 
 export class Paris<TConfigData = any> {
 	private readonly repositories:Map<DataEntityType, IRepository<ModelBase>> = new Map;
@@ -146,7 +147,7 @@ export class Paris<TConfigData = any> {
 	 * @returns {Observable<TResult>} An Observable of the api call's result data type
 	 */
 	apiCall<TResult = any, TInput = any>(apiCallType:ApiCallType<TResult, TInput>, input?:TInput, dataOptions:DataOptions = defaultDataOptions):Observable<TResult>{
-		const cacheKey:string = JSON.stringify(input) || "{}";
+		const cacheKey:string = jsonStringify(input || {});
 
 		if (dataOptions.allowCache) {
 			const apiCallTypeCache: DataCache<TResult> = this.getApiCallCache<TResult, TInput>(apiCallType);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@types/gulp-sass": "^0.0.30",
 		"@types/gulp-util": "^3.0.29",
 		"@types/jest": "^23.3.1",
+		"@types/json-stringify-safe": "^5.0.0",
 		"@types/lodash-es": "4.17.1",
 		"@types/node": "^8.0.25",
 		"@types/rimraf": "2.0.2",
@@ -63,6 +64,7 @@
 		"husky": "^1.0.0-rc.13",
 		"intl": "^1.2.5",
 		"jest": "^23.5.0",
+		"json-stringify-safe": "^5.0.1",
 		"lodash-es": "4.17.10",
 		"merge2": "^1.0.2",
 		"reflect-metadata": "^0.1.12",
@@ -85,6 +87,9 @@
 		"rxjs": ">=6.0.0",
 		"lodash-es": "4.5.0"
 	},
+	"bundledDependencies": [
+		"json-stringify-safe"
+	],
 	"jest": {
 		"transform": {
 			"^.+\\.(js|ts)$": "ts-jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Library for the implementation of Domain Driven Design in Angular/TypeScript apps",
 	"repository": {
 		"type": "git",

--- a/test/mock/update-todo.api-call.ts
+++ b/test/mock/update-todo.api-call.ts
@@ -1,0 +1,12 @@
+import { ApiCallModel } from "../../lib/api/api-calls/api-call.model";
+import { ApiCall } from "../../lib/config/decorators/api-call.decorator";
+import { Todo } from "./todo.entity";
+
+@ApiCall({
+	name: "Update a todo item",
+	endpoint: "update_todo_item",
+	method: "POST",
+	cache: true,
+})
+export class UpdateTodoApiCall extends ApiCallModel<Todo, Todo>{
+}


### PR DESCRIPTION
Currently Paris uses `JSON.stringify` as an object hash when making usage of `ApiCall`.
This doesn't allow abstraction of parameter extraction from an entity, for example:
```typescript
@Entity({
  ...
})
export class Todo extends EntityModelBase<string> {
  ...
}

@ApiCall({
  ...
  endpoint: (config, query) => `todos/${todoId}/comment`
  parseQuery: (todo: Todo) => ({ todoId: todo.id })
})
export class TodoCommentApiCall extends ApiCallModel<..., Todo> {}
```

since `Todo` is an `EntityModelBase` it has a `$parent` property which may be a circular reference.

In this case we can change the parameters of `TodoCommentApiCall` to be `{ todoId: Todo['id'] }`, but if you have more than a few things you need from the entity, this is very cumbersome, and is prone to code duplication in the application (each usage needs to extract the parameters from the entity before handing off to Paris).

The solution is to use a more safe approach to hashing, namely [`json-stringify-safe`](https://www.npmjs.com/package/json-stringify-safe), to create the same mechanism for creating the keys, but stop at circular references (which `JSON.strinfigy` doesn't do by default).

No breaking changes expected, apart from adding another `peerDependency` (this can be mitigated with adding `object-hash` as a `bundleDependencies`, but I'd like to avoid it if possible, if only to reduce the chance of duplicated libraries in different versions at runtime).
Note that this is an `optionalDependencies` since if you don't use caching or `ApiCall`s at all - this is unneeded.

---
An earlier attempt was made at this at #7, which used [`object-hash`](https://www.npmjs.com/package/object-hash), but was dropped [due to](https://github.com/Microsoft/paris/pull/7#issuecomment-414119439):
> I found an issue where object-hash will evaluate getter functions, which should not be part of the hash really, since they're essentially a computed value on top of the raw data.
I'll change the implementation to a regular JSON.stringify (which does not do the above) and pass a replacer to deal with cycllic dependencies and send another PR for that, since it changes most of the code in this one.