### PR TITLE
Fix `modelWith` causing an infinite recursion

### DIFF
--- a/lib/modeling/modeler.ts
+++ b/lib/modeling/modeler.ts
@@ -46,12 +46,14 @@ export class Modeler {
 		let getModelDataError:Error = new Error(`Failed to create ${entity.singularName}.`);
 
 		if (typeof entity.modelWith === 'function') {
-			const { entityConfig, valueObjectConfig } = entity.modelWith(rawData);
-			return this.modelEntity<TConcreteEntity, TRawData>(
-				rawData,
-				entityConfig || valueObjectConfig,
-				options
-			);
+			const modelWithEntity = entity.modelWith(rawData);
+			if (modelWithEntity) {
+				return this.modelEntity<TConcreteEntity, TRawData>(
+					rawData,
+					modelWithEntity.entityConfig || modelWithEntity.valueObjectConfig,
+					options
+				);
+			}
 		}
 
 		entity.fields.forEach((entityField: Field) => {


### PR DESCRIPTION
When `modelWith` returns the same entity type, Paris goes into an infinite recursion, trying to call `modelWith` on itself.
This fix makes it so that returning a falsy value (i.e. `null` or `undefined`), or the same data type as that defined on the `modelWith`, will simply model what it can - using the existing type.	