### PR TITLE
Assigning a model's data in the modeler rather than in the constructo…

### DIFF
--- a/lib/config/entity-model.base.ts
+++ b/lib/config/entity-model.base.ts
@@ -6,8 +6,4 @@ import {EntityId} from "../modeling/entity-id.type";
 export class EntityModelBase<TId extends EntityId = string> extends ModelBase{
 	@EntityField()
 	id:TId;
-
-	constructor(data:EntityModelConfigBase){
-		super(data);
-	}
 }

--- a/lib/config/model.base.ts
+++ b/lib/config/model.base.ts
@@ -1,6 +1,7 @@
 export class ModelBase{
 	id?:any;
 	$parent?:ModelBase;
+	_init?: (entityData?:any, rawData?:any) => never;
 
 	constructor(data?:any){
 		if (data) {

--- a/lib/modeling/modeler.ts
+++ b/lib/modeling/modeler.ts
@@ -121,6 +121,12 @@ export class Modeler {
 
 			try {
 				model = new entity.entityConstructor(modelData, rawData);
+				if (Object.isFrozen(model) || Object.isSealed(model))
+					console.warn(`Can't assign data to ${entity.singularName}, since it's frozen or sealed.`);
+
+				Object.assign(model, modelData);
+				if (model._init)
+					model._init(modelData, rawData);
 			} catch (e) {
 				getModelDataError.message = getModelDataError.message + " Error: " + e.message;
 				throw getModelDataError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.4.3",
+	"version": "1.5.0",
 	"description": "Library for the implementation of Domain Driven Design with TypeScript + RxJS",
 	"repository": {
 		"type": "git",
@@ -63,7 +63,7 @@
 		"gulp-typescript": "^3.1.3",
 		"husky": "^1.0.0-rc.13",
 		"intl": "^1.2.5",
-		"jest": "^24.7.1",
+		"jest": "^23.6.0",
 		"json-stringify-safe": "^5.0.1",
 		"lodash-es": "4.17.10",
 		"merge2": "^1.0.2",


### PR DESCRIPTION
…r, to make the modeler work properly with Babel, which doesn't call the parent's constructor of a class.