### PR TITLE
revert breaking changes in 8e9213b, 5225d63

### DIFF
--- a/lib/config/entity-model.base.ts
+++ b/lib/config/entity-model.base.ts
@@ -6,4 +6,8 @@ import {EntityId} from "../modeling/entity-id.type";
 export class EntityModelBase<TId extends EntityId = string> extends ModelBase{
 	@EntityField()
 	id:TId;
+
+	constructor(data:EntityModelConfigBase){
+		super(data);
+	}
 }

--- a/lib/config/model.base.ts
+++ b/lib/config/model.base.ts
@@ -1,7 +1,6 @@
 export class ModelBase{
 	id?:any;
 	$parent?:ModelBase;
-	_init?: (entityData?:any, rawData?:any) => never;
 
 	constructor(data?:any){
 		if (data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/paris",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"description": "Library for the implementation of Domain Driven Design with TypeScript + RxJS",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
these commits accidentally introduce a breaking
change - if you manually set a field in a model
that is a subclass of another model, that field
gets overwritten (typically with null) on model
creation.

Example: `CatModel` and `DogModel` both extend
`AnimalModel` and set the `family` property to
`'canine'` and `'feline'` respectively.

When either `CatModel` or `DogModel` are created,
the `family` field will be overwritten when
the modeldata (which doesn't have a family value)
is copied to the model.