### PR TITLE
fix: README bracket spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { Entity, EntityModelBase, EntityField } from "@microsoft/paris";
 	pluralName: "Todo Items",
 	endpoint: "todo/items"
 })
-export class TodoItem extends EntityModelBase{
+export class TodoItem extends EntityModelBase {
 	@EntityField()
 	text: string;
 


### PR DESCRIPTION
Simple README Fix, just adds a space on the bracket for the first usage example