### PR TITLE
Update lodash-es version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"intl": "^1.2.5",
 		"jest": "^24.7.1",
 		"json-stringify-safe": "^5.0.1",
-		"lodash-es": "4.17.15",
+		"lodash-es": "4.17.21",
 		"merge2": "^1.0.2",
 		"reflect-metadata": "^0.1.12",
 		"rimraf": "~2.5.4",
@@ -85,7 +85,7 @@
 	},
 	"peerDependencies": {
 		"rxjs": ">=6.4.0",
-		"lodash-es": "4.5.0"
+		"lodash-es": "4.17.21"
 	},
 	"bundledDependencies": [
 		"json-stringify-safe"


### PR DESCRIPTION
Updated the lodash-es version for `peerDependencies` and `devDependencies`, so it derives from `4.17.21` which includes a security fix present in earlier versions of lodash