### PR TITLE
allow manually specifying type

### DIFF
--- a/lib/config/decorators/entity-field.decorator.ts
+++ b/lib/config/decorators/entity-field.decorator.ts
@@ -11,9 +11,9 @@ import {Field} from "../../api/entity/entity-field";
  */
 export function EntityField(fieldConfig?:FieldConfig):PropertyDecorator {
 	return function (entityPrototype: DataEntityType, propertyKey: string | symbol) {
-		let propertyConstructor:Function = (<any>Reflect).getMetadata("design:type", entityPrototype, propertyKey);
 
 		fieldConfig = fieldConfig || {};
+		let propertyConstructor:Function = fieldConfig.type || (<any>Reflect).getMetadata("design:type", entityPrototype, propertyKey);
 		let field:Field = Object.assign({}, fieldConfig);
 		if (!field.id)
 			field.id = String(propertyKey);

--- a/lib/config/entity-field.config.ts
+++ b/lib/config/entity-field.config.ts
@@ -17,6 +17,11 @@ export interface FieldConfig{
 	name?:string,
 
 	/**
+	 * Optional type constructor to override the type Paris gets from decoratorMetadata. Useful for using Paris without emitDecoratorMetadata
+	 */
+	type?:any
+
+	/**
 	 * Specifies which property in the raw data should be assigned to the model's property.
 	 * By default, Paris looks for a property of the same name as the property in the model. i.e:
 	 *


### PR DESCRIPTION
Reflect metadata is dead.
The old decorator proposal is dead.
The new decorator proposal isn't "ready".
TypeScript does not support reflect metadata with a newer than ES5 target.
Long live TypeScript.
https://github.com/angular/angular-cli/issues/15077