### PR TITLE
Fix isArray status when passing `type`

### DIFF
--- a/lib/config/decorators/entity-field.decorator.ts
+++ b/lib/config/decorators/entity-field.decorator.ts
@@ -19,7 +19,7 @@ export function EntityField(fieldConfig?:FieldConfig):PropertyDecorator {
 			field.id = String(propertyKey);
 
 		field.type = fieldConfig.arrayOf || propertyConstructor;
-		field.isArray = propertyConstructor === Array;
+		field.isArray = propertyConstructor === Array || Boolean(fieldConfig.arrayOf);
 		entityFieldsService.addField(entityPrototype, field);
 	}
 }


### PR DESCRIPTION
when not using Reflect.getMetadata isArray is not populated correctly at the moment.